### PR TITLE
build: Fix the lodash issue with the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "tslint-config-prettier": "^1.1.0",
     "tslint-config-standard": "^7.0.0",
     "typedoc": "^0.9.0",
-    "typescript": "^2.7.1",
+    "typescript": "2.6.2",
     "validate-commit-msg": "^2.12.2"
   },
   "dependencies": {


### PR DESCRIPTION
Lock typescript version because they don't follow semver

closes the #4 issue